### PR TITLE
Add unit tests, refactor ContactService, and improve tests

### DIFF
--- a/02_Application/Service/ContactService.cs
+++ b/02_Application/Service/ContactService.cs
@@ -20,9 +20,12 @@ namespace Application.Service
         {
             var ddd = await _directDistanceDialingRepository.GetByIdAsync(dddId);
 
-            return ddd is null
-                ? throw new ArgumentException("Invalid Direct Distance Dialing Id")
-                : await _contactRepository.GetAllByDddAsync(dddId);
+            if (ddd is null)
+                throw new ArgumentException("Invalid Direct Distance Dialing Id");
+
+            var contacts = await _contactRepository.GetAllByDddAsync(dddId);
+            return contacts ?? new List<Contact>();
+
         }
     }
 }

--- a/05_UnitTest/05_UnitTest.csproj
+++ b/05_UnitTest/05_UnitTest.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>UnitTest</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.15" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\02_Application\02_Application.csproj" />
+    <ProjectReference Include="..\03_Core\03_Core.csproj" />
+    <ProjectReference Include="..\04_Infraestructure\04_Infraestructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/05_UnitTest/Application/Service/ContactServiceTests.cs
+++ b/05_UnitTest/Application/Service/ContactServiceTests.cs
@@ -1,0 +1,91 @@
+﻿using Application.Service;
+using Core.Entity;
+using Core.Repository.Interface;
+using Moq;
+
+namespace UnitTest.Application.Service;
+public class ContactServiceTests
+{
+    private readonly Mock<IContactRepository> _mockContactRepository;
+    private readonly Mock<IDirectDistanceDialingRepository> _mockDddRepository;
+    private readonly ContactService _contactService;
+
+    public ContactServiceTests()
+    {
+        _mockContactRepository = new Mock<IContactRepository>();
+        _mockDddRepository = new Mock<IDirectDistanceDialingRepository>();
+        _contactService = new ContactService(_mockContactRepository.Object, _mockDddRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_ValidDddId_ReturnsContacts()
+    {
+        // Arrange
+        int dddId = 11;
+        var ddd = new DirectDistanceDialing { Id = dddId, Region = "São Paulo", CreatedOn = DateTime.Now };
+        var contacts = new List<Contact>
+        {
+            new() { Id = 1, Name = "Test User 1", Phone = "99983-1617", Email="testUser1@gmail.com", DddId= dddId },
+            new() { Id = 2, Name = "Test User 2" , Phone= "99983-1618", Email="testUser2@gmail.com", DddId= dddId }
+        };
+
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(ddd);
+        _mockContactRepository.Setup(repo => repo.GetAllByDddAsync(dddId)).ReturnsAsync(contacts);
+
+        // Act
+        var result = await _contactService.GetAllByDddAsync(dddId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_InvalidDddId_ThrowsArgumentException()
+    {
+        // Arrange
+        int dddId = 999;
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(value: null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => _contactService.GetAllByDddAsync(dddId));
+        Assert.Equal("Invalid Direct Distance Dialing Id", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_ValidDddId_NoContacts_ReturnsEmptyList()
+    {
+        // Arrange
+        int dddId = 21;
+        var ddd = new DirectDistanceDialing { Id = dddId, Region = "Rio de Janeiro", CreatedOn = DateTime.Now };
+        var emptyContactList = new List<Contact>();
+
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(ddd);
+        _mockContactRepository.Setup(repo => repo.GetAllByDddAsync(dddId)).ReturnsAsync(emptyContactList);
+
+        // Act
+        var result = await _contactService.GetAllByDddAsync(dddId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_ValidDddId_ContactRepositoryReturnsNull_ReturnsEmptyList()
+    {
+        // Arrange
+        int dddId = 31;
+        var ddd = new DirectDistanceDialing { Id = dddId, Region = "Belo Horizonte", CreatedOn = DateTime.Now };
+
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(ddd);
+        _mockContactRepository.Setup(repo => repo.GetAllByDddAsync(dddId)).ReturnsAsync(value: null);
+
+        // Act
+        var result = await _contactService.GetAllByDddAsync(dddId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}

--- a/05_UnitTest/Application/Service/DirectDistanceDialingServiceTests.cs
+++ b/05_UnitTest/Application/Service/DirectDistanceDialingServiceTests.cs
@@ -1,0 +1,113 @@
+﻿using Application.Service;
+using Core.Entity;
+using Core.Repository.Interface;
+using Moq;
+
+namespace UnitTest.Application.Service;
+public class DirectDistanceDialingServiceTests
+{
+    private readonly Mock<IDirectDistanceDialingRepository> _mockDddRepository;
+    private readonly DirectDistanceDialingService _directDistanceDialingService;
+
+    public DirectDistanceDialingServiceTests()
+    {
+        _mockDddRepository = new Mock<IDirectDistanceDialingRepository>();
+        _directDistanceDialingService = new DirectDistanceDialingService(_mockDddRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllDirectDistanceDialing()
+    {
+        // Arrange
+        var ddds = new List<DirectDistanceDialing>
+        {
+            new() { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now },
+            new() { Id = 21, Region = "Rio de Janeiro", CreatedOn = DateTime.Now },
+            new() { Id = 51, Region = "Rio Grande do Sul", CreatedOn = DateTime.Now },
+        };
+
+        _mockDddRepository.Setup(repo => repo.GetAllAsync()).ReturnsAsync(ddds);
+
+        // Act
+        var result = await _directDistanceDialingService.GetAllAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingId_ReturnsDirectDistanceDialing()
+    {
+        // Arrange
+        int dddId = 11;
+        var ddd = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(ddd);
+
+        // Act
+        var result = await _directDistanceDialingService.GetByIdAsync(dddId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(dddId, result.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NonExistingId_ReturnsNull()
+    {
+        // Arrange
+        int dddId = 999;
+
+        _mockDddRepository.Setup(repo => repo.GetByIdAsync(dddId)).ReturnsAsync(value: null);
+
+        // Act
+        var result = await _directDistanceDialingService.GetByIdAsync(dddId);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidEntity_CallsRepositoryCreate()
+    {
+        // Arrange
+        var newDdd = new DirectDistanceDialing { Id = 21, Region = "Rio de Janeiro", CreatedOn = DateTime.Now };
+
+        _mockDddRepository.Setup(repo => repo.CreateAsync(newDdd)).Returns(Task.CompletedTask);
+
+        // Act
+        await _directDistanceDialingService.CreateAsync(newDdd);
+
+        // Assert
+        _mockDddRepository.Verify(repo => repo.CreateAsync(newDdd), Times.Once);
+    }
+
+    [Fact]
+    public async Task EditAsync_ValidEntity_CallsRepositoryEdit()
+    {
+        // Arrange
+        var existingDdd = new DirectDistanceDialing { Id = 51, Region = "Rio Grande do Sul", CreatedOn = DateTime.Now };
+        _mockDddRepository.Setup(repo => repo.EditAsync(existingDdd)).Returns(Task.CompletedTask);
+
+        // Act
+        await _directDistanceDialingService.EditAsync(existingDdd);
+
+        // Assert
+        _mockDddRepository.Verify(repo => repo.EditAsync(existingDdd), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ValidEntity_CallsRepositoryDelete()
+    {
+        // Arrange
+        var dddToDelete = new DirectDistanceDialing { Id = 51, Region = "Rio Grande do Sul", CreatedOn = DateTime.Now };
+        _mockDddRepository.Setup(repo => repo.DeleteAsync(dddToDelete)).Returns(Task.CompletedTask);
+
+        // Act
+        await _directDistanceDialingService.DeleteAsync(dddToDelete);
+
+        // Assert
+        _mockDddRepository.Verify(repo => repo.DeleteAsync(dddToDelete), Times.Once);
+    }
+}

--- a/05_UnitTest/Infraestructure/Configuration/InMemoryDbOptionsFactory.cs
+++ b/05_UnitTest/Infraestructure/Configuration/InMemoryDbOptionsFactory.cs
@@ -1,0 +1,14 @@
+﻿using Infraestructure.Configuration;
+using Microsoft.EntityFrameworkCore;
+
+namespace UnitTest.Infraestructure.Configuration;
+public static class InMemoryDbOptionsFactory
+{
+    public static DbContextOptions<DataContext> CreateUniqueInMemoryOptions()
+    {
+        // Use an in-memory database for testing
+        return new DbContextOptionsBuilder<DataContext>()
+        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // Unique database per test
+        .Options;
+    }
+}

--- a/05_UnitTest/Infraestructure/Repository/ContactRepositoryTests.cs
+++ b/05_UnitTest/Infraestructure/Repository/ContactRepositoryTests.cs
@@ -1,0 +1,73 @@
+﻿using Core.Entity;
+using Infraestructure.Configuration;
+using Infraestructure.Repository;
+using Microsoft.EntityFrameworkCore;
+using UnitTest.Infraestructure.Configuration;
+
+namespace UnitTest.Infraestructure.Repository;
+public class ContactRepositoryTests
+{
+    private readonly DbContextOptions<DataContext> _options;
+
+    public ContactRepositoryTests()
+    {
+        // Use an in-memory database for testing
+        _options = InMemoryDbOptionsFactory.CreateUniqueInMemoryOptions();
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_ValidDddId_ReturnsContacts()
+    {
+        // Arrange
+        using (var context = new DataContext(_options))
+        {
+            // Seed data
+            var ddd = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.DirectDistanceDialings.Add(ddd);
+
+            var contact1 = new Contact { Id = 1, Name = "Test User 1", Phone = "99983-1617", Email = "testUser1@gmail.com", DddId = ddd.Id };
+            var contact2 = new Contact { Id = 2, Name = "Test User 2", Phone = "99983-1618", Email = "testUser2@gmail.com", DddId = ddd.Id };
+            var unrelatedContact = new Contact { Id = 3, Name = "Test User 3", Phone = "99983-1618", Email = "testUser3@gmail.com", DddId = 21 };
+
+            context.Contacts.AddRange(contact1, contact2, unrelatedContact);
+            await context.SaveChangesAsync();
+
+            var repository = new ContactRepository(context);
+
+            // Act
+            var result = await repository.GetAllByDddAsync(11);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, c => c.Name == "Test User 1");
+            Assert.Contains(result, c => c.Name == "Test User 2");
+        }
+    }
+
+    [Fact]
+    public async Task GetAllByDddAsync_InvalidDddId_ReturnsEmptyList()
+    {
+        // Arrange
+        using (var context = new DataContext(_options))
+        {
+            // Seed data
+            var ddd = new DirectDistanceDialing { Id = 12, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.DirectDistanceDialings.Add(ddd);
+
+            var contact = new Contact { Id = 1, Name = "Test User 1", Phone = "99983-1617", Email = "testUser1@gmail.com", DddId = ddd.Id };
+            context.Contacts.Add(contact);
+            await context.SaveChangesAsync();
+
+            var invalidDddId = 999;
+            var repository = new ContactRepository(context);
+
+            // Act
+            var result = await repository.GetAllByDddAsync(invalidDddId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+    }
+}

--- a/05_UnitTest/Infraestructure/Repository/DirectDistanceDialingRepositoryTests.cs
+++ b/05_UnitTest/Infraestructure/Repository/DirectDistanceDialingRepositoryTests.cs
@@ -1,0 +1,153 @@
+﻿using Core.Entity;
+using Infraestructure.Configuration;
+using Infraestructure.Repository;
+using Microsoft.EntityFrameworkCore;
+using UnitTest.Infraestructure.Configuration;
+
+namespace UnitTest.Infraestructure.Repository;
+public class DirectDistanceDialingRepositoryTests
+{
+    private readonly DbContextOptions<DataContext> _options;
+
+    public DirectDistanceDialingRepositoryTests()
+    {
+        // Use an in-memory database for testing
+        _options = InMemoryDbOptionsFactory.CreateUniqueInMemoryOptions();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsDirectDistanceDialings()
+    {
+        //Arrange
+        using (var context = new DataContext(_options))
+        {
+            // Seed data
+            var ddd1 = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            var ddd2 = new DirectDistanceDialing { Id = 12, Region = "São Paulo", CreatedOn = DateTime.Now };
+            var ddd3 = new DirectDistanceDialing { Id = 13, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.DirectDistanceDialings.AddRange(ddd1, ddd2, ddd3);
+
+            await context.SaveChangesAsync();
+
+            var repository = new DirectDistanceDialingRepository(context);
+
+            // Act
+            var result = await repository.GetAllAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count);
+            Assert.Contains(result, c => c.Id == 11);
+            Assert.Contains(result, c => c.Id == 12);
+            Assert.Contains(result, c => c.Id == 13);
+        }
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingId_ReturnsDirectDistanceDialing()
+    {
+        using (var context = new DataContext(_options))
+        {
+            //Arrange
+            var ddd1 = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.DirectDistanceDialings.Add(ddd1);
+
+            await context.SaveChangesAsync();
+
+            var repository = new DirectDistanceDialingRepository(context);
+
+            // Act
+            var dddId = 11;
+            var result = await repository.GetByIdAsync(dddId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(dddId, result.Id);
+        }
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NonExistingId_ReturnsNull()
+    {
+        using (var context = new DataContext(_options))
+        {
+            //Arrange
+            var ddd1 = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.DirectDistanceDialings.Add(ddd1);
+
+            await context.SaveChangesAsync();
+
+            var repository = new DirectDistanceDialingRepository(context);
+
+            // Act
+            var dddId = 999;
+            var result = await repository.GetByIdAsync(dddId);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidEntity_AddsEntity()
+    {
+        using (var context = new DataContext(_options))
+        {
+            // Arrange
+            var repository = new DirectDistanceDialingRepository(context);
+            var ddd = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+
+            // Act
+            await repository.CreateAsync(ddd);
+
+            // Assert
+            var result = await context.Set<DirectDistanceDialing>().FirstOrDefaultAsync(e => e.Id == 11);
+            Assert.NotNull(result);
+            Assert.Equal(11, result.Id);
+        }
+    }
+
+    [Fact]
+    public async Task EditAsync_ExistingEntity_UpdatesEntity()
+    {
+        using (var context = new DataContext(_options))
+        {
+            // Arrange
+            var ddd = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.Add(ddd);
+            await context.SaveChangesAsync();
+
+            var repository = new DirectDistanceDialingRepository(context);
+
+            // Act
+            ddd.Region = "São Paulo Upated";
+            await repository.EditAsync(ddd);
+
+            // Assert
+            var result = await context.Set<DirectDistanceDialing>().FirstOrDefaultAsync(e => e.Id == 11);
+            Assert.NotNull(result);
+            Assert.Equal("São Paulo Upated", result.Region);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ExistingEntity_RemovesEntity()
+    {
+        using (var context = new DataContext(_options))
+        {
+            // Arrange
+            var ddd = new DirectDistanceDialing { Id = 11, Region = "São Paulo", CreatedOn = DateTime.Now };
+            context.Add(ddd);
+            await context.SaveChangesAsync();
+
+            var repository = new DirectDistanceDialingRepository(context);
+
+            // Act
+            await repository.DeleteAsync(ddd);
+
+            // Assert
+            var result = await context.Set<DirectDistanceDialing>().FirstOrDefaultAsync(e => e.Id == 11);
+            Assert.Null(result);
+        }
+    }
+}

--- a/TechChallegeFase3-Contat-Storage.sln
+++ b/TechChallegeFase3-Contat-Storage.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "04_Infraestructure", "04_In
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "02_Application", "02_Application\02_Application.csproj", "{C7B4E136-EC78-46F6-98FE-2B85E1FFAAE8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "05_UnitTest", "05_UnitTest\05_UnitTest.csproj", "{4990D3E1-FD4B-4155-8715-00BCD2995335}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{C7B4E136-EC78-46F6-98FE-2B85E1FFAAE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7B4E136-EC78-46F6-98FE-2B85E1FFAAE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7B4E136-EC78-46F6-98FE-2B85E1FFAAE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4990D3E1-FD4B-4155-8715-00BCD2995335}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4990D3E1-FD4B-4155-8715-00BCD2995335}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4990D3E1-FD4B-4155-8715-00BCD2995335}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4990D3E1-FD4B-4155-8715-00BCD2995335}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Refactored `GetAllByDddAsync` in `ContactService` to improve null handling and maintainability. Added a new unit test project (`05_UnitTest`) targeting .NET 8.0 with `xunit`, `Moq`, and EF Core In-Memory. Implemented unit and integration tests for `ContactService`, `DirectDistanceDialingService`, and their respective repositories. Introduced reusable in-memory database configuration for testing. Enhanced test coverage and ensured edge case handling.